### PR TITLE
Make configure.bat work with VC9

### DIFF
--- a/win/configure.bat
+++ b/win/configure.bat
@@ -47,7 +47,7 @@ goto :lp
 
 :: ARCH is native ABI
 set ARCH=64
-if %PROCESSOR_ARCHITECTURE% == x86 ( set ARCH=32)
+if %CPU% == x86 ( set ARCH=32)
 set VCTARGET=
 if %ARCH% == 64 (
 	if %ABI% == 64 (set VCTARGET=amd64)


### PR DESCRIPTION
%PROCESSOR_ARCHITECTURE% is not defined in VC9
